### PR TITLE
Move static assets to /static

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <link rel="stylesheet" href="/style.css">
+    <link rel="stylesheet" href="/static/style.css">
   </head>
   <body>
     <div id="root"></div>
-    <script src="/main.js"></script>
+    <script src="/static/main.js"></script>
   </body>
 </html>

--- a/server/index.js
+++ b/server/index.js
@@ -59,7 +59,14 @@ var routes = function(err) {
   server.route([
     {
       method: 'GET',
-      path: '/{param*}',
+      path: '/',
+      handler: function(req, reply) {
+        reply.file('../build/index.html');
+      },
+    },
+    {
+      method: 'GET',
+      path: '/static/{param*}',
       handler: {
         directory: {
           path: '.',


### PR DESCRIPTION
This is so path based routing in the load balancer can send them
to the correct server, S3, etc.